### PR TITLE
Fix the crash related to marking the challenge as completed.

### DIFF
--- a/Habit-Calendar/Habit-Calendar/Controllers/HabitDetailsViewController/HabitDetailsViewController.swift
+++ b/Habit-Calendar/Habit-Calendar/Controllers/HabitDetailsViewController/HabitDetailsViewController.swift
@@ -356,11 +356,17 @@ class HabitDetailsViewController: UIViewController {
     /// - Note: The challenge is found if the date is in between or is it's begin or final.
     /// - Returns: The challenge entity, if any.
     func getChallenge(from date: Date) -> DaysChallengeMO? {
+        let date = date.getBeginningOfDay()
         // Try to get the matching challenge by filtering through the habit's fetched ones.
         // The challenge matches when the passed date or is in between,
         // or is one of the challenge's limit dates (begin or end).
         let filteredChallenges = challenges.filter {
-            date.isInBetween($0.fromDate!, $0.toDate!) || date == $0.fromDate! || date == $0.toDate!
+            let fromDate = $0.fromDate!.getBeginningOfDay()
+            let toDate = $0.toDate!.getBeginningOfDay()
+
+            return date.isInBetween(fromDate, toDate) ||
+                date.compare(fromDate) == .orderedSame ||
+                date.compare(toDate) == .orderedSame
         }
 
         // If there's more than one challenge, filter by the ones that are open.

--- a/Habit-Calendar/Habit-Calendar/Controllers/HabitsTableViewController/HabitsTableViewController.swift
+++ b/Habit-Calendar/Habit-Calendar/Controllers/HabitsTableViewController/HabitsTableViewController.swift
@@ -135,13 +135,7 @@ class HabitsTableViewController: UITableViewController {
         super.viewWillAppear(animated)
 
         // Start fetching for the habits.
-        // TODO: Check what errors are thrown by the fetch. Every error should be reported to the user.
-        do {
-            displayEmptyStateIfNeeded()
-            try selectedFetchedResultsController.performFetch()
-        } catch {
-            assertionFailure("Error: Couldn't fetch the user's habits.")
-        }
+        updateList()
     }
 
     // MARK: Navigation

--- a/Habit-Calendar/Habit-Calendar/Controllers/HabitsTableViewController/HabitsTableViewController.swift
+++ b/Habit-Calendar/Habit-Calendar/Controllers/HabitsTableViewController/HabitsTableViewController.swift
@@ -320,7 +320,7 @@ extension HabitsTableViewController: NotificationObserver {
 extension HabitsTableViewController: AppActiveObserver {
     func handleActivationEvent(_ notification: Notification) {
         Timer.scheduledTimer(withTimeInterval: 0.1, repeats: false) { _ in
-            // Reset the current fetched results controller, so its query always takes today into account.
+            // Reset the current fetched results controller, so its predicate always takes today into account.
             switch self.selectedSegment {
             case .inProgress:
                 self._progressfetchedResultsController = nil

--- a/Habit-Calendar/Habit-Calendar/Extensions/Date+Utils.swift
+++ b/Habit-Calendar/Habit-Calendar/Extensions/Date+Utils.swift
@@ -41,7 +41,7 @@ extension Date {
     /// Gets the configured current calendar.
     private func getCurrentCalendar() -> Calendar {
         var calendar = Calendar.current
-        calendar.timeZone = TimeZone.current
+        calendar.timeZone = TimeZone.autoupdatingCurrent
 
         return calendar
     }

--- a/Habit-Calendar/Habit-Calendar/Storage/HabitStorage.swift
+++ b/Habit-Calendar/Habit-Calendar/Storage/HabitStorage.swift
@@ -54,9 +54,16 @@ class HabitStorage {
     /// - Parameter context: The context used to fetch the habits.
     /// - Returns: The created fetched results controller.
     func makeCompletedFetchedResultsController(context: NSManagedObjectContext) -> NSFetchedResultsController<HabitMO> {
-        // Filter for habits that don't have an active days' challenge (aren't closed yet).
+        // Filter for habits that don't have an active days' challenge
+        // (aren't closed yet or date is not in between the challenge).
         let completedPredicate = NSPredicate(
-            format: "SUBQUERY(challenges, $challenge, $challenge.isClosed == false).@count == 0"
+            format: """
+SUBQUERY(challenges, $challenge,
+    $challenge.isClosed == false AND $challenge.fromDate <= %@ AND %@ <= $challenge.toDate
+).@count == 0
+""",
+            Date().getBeginningOfDay() as NSDate,
+            Date().getBeginningOfDay() as NSDate
         )
         let request: NSFetchRequest<HabitMO> = HabitMO.fetchRequest()
         request.predicate = completedPredicate
@@ -85,7 +92,7 @@ class HabitStorage {
         let inProgressPredicate = NSPredicate(
             format: """
 SUBQUERY(challenges, $challenge,
-$challenge.isClosed == false AND $challenge.fromDate <= %@ AND %@ <= $challenge.toDate
+    $challenge.isClosed == false AND $challenge.fromDate <= %@ AND %@ <= $challenge.toDate
 ).@count > 0
 """,
             Date().getBeginningOfDay() as NSDate,

--- a/Habit-Calendar/Habit-Calendar/Storage/HabitStorage.swift
+++ b/Habit-Calendar/Habit-Calendar/Storage/HabitStorage.swift
@@ -83,7 +83,13 @@ class HabitStorage {
     func makeFetchedResultsController(context: NSManagedObjectContext) -> NSFetchedResultsController<HabitMO> {
         // Filter for habits that have an active days' challenge.
         let inProgressPredicate = NSPredicate(
-            format: "SUBQUERY(challenges, $challenge, $challenge.isClosed == false).@count == 1"
+            format: """
+SUBQUERY(challenges, $challenge,
+$challenge.isClosed == false AND $challenge.fromDate <= %@ AND %@ <= $challenge.toDate
+).@count >= 1
+""",
+            Date().getBeginningOfDay() as NSDate,
+            Date().getBeginningOfDay() as NSDate
         )
         let request: NSFetchRequest<HabitMO> = HabitMO.fetchRequest()
         request.predicate = inProgressPredicate

--- a/Habit-Calendar/Habit-Calendar/Storage/HabitStorage.swift
+++ b/Habit-Calendar/Habit-Calendar/Storage/HabitStorage.swift
@@ -86,7 +86,7 @@ class HabitStorage {
             format: """
 SUBQUERY(challenges, $challenge,
 $challenge.isClosed == false AND $challenge.fromDate <= %@ AND %@ <= $challenge.toDate
-).@count >= 1
+).@count > 0
 """,
             Date().getBeginningOfDay() as NSDate,
             Date().getBeginningOfDay() as NSDate

--- a/Habit-Calendar/Habit-Calendar/Supporting Files/AppDelegate.swift
+++ b/Habit-Calendar/Habit-Calendar/Supporting Files/AppDelegate.swift
@@ -100,12 +100,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Register the app for any UserNotification's events.
         UNUserNotificationCenter.current().delegate = self
 
-        // Close any past challenges that are open.
-        persistentContainer.performBackgroundTask { context in
-            self.daysChallengeStorage.closePastChallenges(using: context)
-            try? context.save()
-        }
-
         // Inject the main dependencies into the initial HabitTableViewController:
         if let habitsListingController = window?.rootViewController?.contents as? HabitsTableViewController {
             habitsListingController.container = persistentContainer
@@ -114,6 +108,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         return true
+    }
+
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        // Close any past challenges that are open.
+        persistentContainer.performBackgroundTask { context in
+            self.daysChallengeStorage.closePastChallenges(using: context)
+            try? context.save()
+        }
     }
 
     func applicationWillTerminate(_ application: UIApplication) {


### PR DESCRIPTION
When the last challenge's day was marked as completed, the fetched results controller from the habits table view wasn't being properly updated, and the table view was being out of sync.

Also makes the habits table view controller update itself when the app becomes active, and changes the inProgress fetched results controller to only bring challenges happening now.

Closes #88.