### PR TITLE
Fix timezone display

### DIFF
--- a/Habit-Calendar/Habit-Calendar-Tests/Integration Tests/Model Tests/DaysChallengeTests.swift
+++ b/Habit-Calendar/Habit-Calendar-Tests/Integration Tests/Model Tests/DaysChallengeTests.swift
@@ -165,6 +165,28 @@ class DaysChallengeTests: IntegrationTestCase {
         XCTAssertNil(habitDay)
     }
 
+    func testGettingDayFromDateNotInBeginning() {
+        // 1. Create a dummy challenge with a date not in the beginning.
+        let dummyChallenge = daysChallengeFactory.makeDummy()
+        let dummyDay = dayFactory.makeDummy()
+
+        var components = Date().components
+        components.hour = 12
+        components.minute = 0
+        components.second = 0
+        let expectedDate = Calendar.current.date(from: components)
+
+        dummyDay.date = expectedDate
+
+        let habitDay = habitDayFactory.makeDummy()
+        habitDay.day = dummyDay
+
+        dummyChallenge.addToDays(habitDay)
+
+        // 2. Try fetching the day.
+        XCTAssertNotNil(dummyChallenge.getDay(for: expectedDate!))
+    }
+
     func testGettingEmptyChallengeCurrentDayShouldBeNil() {
         // 1. Create an empty dummy challenge.
         let emptyDummyChallenge = DaysChallengeMO(

--- a/Habit-Calendar/Habit-Calendar/Controllers/HabitDetailsViewController/HabitDetailsViewController+Calendar.swift
+++ b/Habit-Calendar/Habit-Calendar/Controllers/HabitDetailsViewController/HabitDetailsViewController+Calendar.swift
@@ -45,12 +45,12 @@ extension HabitDetailsViewController: CalendarDisplayable {
                 cell.dayTitleLabel.textColor = .white
 
                 // Change the cell's range type, if it's the challenge's begin date, end date, or if it's in between.
-                if cellState.date == challenge.fromDate {
+                if cellState.date == challenge.fromDate!.getBeginningOfDay() {
                     cell.position = .begin
+                } else if cellState.date == challenge.toDate!.getBeginningOfDay() {
+                    cell.position = .end
                 } else if cellState.date.isInBetween(challenge.fromDate!, challenge.toDate!) {
                     cell.position = .inBetween
-                } else if cellState.date == challenge.toDate {
-                    cell.position = .end
                 }
 
                 if cellState.date.isInToday {

--- a/Habit-Calendar/Habit-Calendar/Model/Managed Objects/DaysChallengeMO.swift
+++ b/Habit-Calendar/Habit-Calendar/Model/Managed Objects/DaysChallengeMO.swift
@@ -18,23 +18,17 @@ class DaysChallengeMO: NSManagedObject {
     /// if there's one.
     /// - Returns: The HabitDayMO entity representing today's date.
     func getCurrentDay() -> HabitDayMO? {
-        let todayPredicate = NSPredicate(
-            format: "day.date >= %@ and day.date <= %@",
-            Date().getBeginningOfDay() as NSDate,
-            Date().getEndOfDay() as NSDate
-        )
-        return days?.filtered(using: todayPredicate).first as? HabitDayMO
+        return getDay(for: Date())
     }
 
     /// Returns the HabitDay associated with the passed date, if found.
     /// - Parameter date: The date associated with the habit day.
     func getDay(for date: Date) -> HabitDayMO? {
-        let beginningDate = date.getBeginningOfDay()
-
         // Declare the predicate to filter for the specific day.
         let dayPredicate = NSPredicate(
-            format: "day.date = %@",
-            beginningDate as NSDate
+            format: "day.date >= %@ and day.date <= %@",
+            date.getBeginningOfDay() as NSDate,
+            date.getEndOfDay() as NSDate
         )
 
         return days?.filtered(using: dayPredicate).first as? HabitDayMO


### PR DESCRIPTION
When time zone changed, the habit details controller wasn't displaying the challenge in the calendar. This PR fixes this problem.

Closes #103.