### PR TITLE
Add new model version to remove property

### DIFF
--- a/Habit-Calendar/Habit-Calendar-Tests/Integration Tests/Manager Tests/NotificationSchedulerTests.swift
+++ b/Habit-Calendar/Habit-Calendar-Tests/Integration Tests/Manager Tests/NotificationSchedulerTests.swift
@@ -124,12 +124,6 @@ class NotificationSchedulerTests: IntegrationTestCase {
 
         // Schedule it by passing the dummy entity.
         notificationScheduler.schedule(dummyNotification) { notification in
-            // Check if it was marked as scheduled.
-            XCTAssertTrue(
-                notification.wasScheduled,
-                "The notification entity should've been scheduled."
-            )
-
             // Check if the notification was indeed scheduled:
             self.notificationCenterMock.getPendingNotificationRequests { requests in
                 // Search for the user notification request associated with it.
@@ -208,11 +202,6 @@ class NotificationSchedulerTests: IntegrationTestCase {
             // that's why a timer is needed here.
             Timer.scheduledTimer(withTimeInterval: 0.01, repeats: false) { _ in
                 for notification in notifications {
-                    // Assert on the wasExecuted property.
-                    XCTAssertTrue(
-                        notification.wasScheduled,
-                        "The notification should have been scheduled."
-                    )
                     // Assert on the identifier.
                     XCTAssertTrue(
                         identifiers.contains(

--- a/Habit-Calendar/Habit-Calendar-Tests/Integration Tests/Storage Tests/HabitStorageNotificationTests.swift
+++ b/Habit-Calendar/Habit-Calendar-Tests/Integration Tests/Storage Tests/HabitStorageNotificationTests.swift
@@ -157,12 +157,6 @@ class HabitStorageNotificationTests: IntegrationTestCase {
                     "All notifications should have been properly scheduled."
                 )
 
-                // - Assert on the notifications' wasScheduled property.
-                XCTAssertTrue(
-                    notifications.filter { !$0.wasScheduled }.count == 0,
-                    "All notifications should have been scheduled."
-                )
-
                 scheduleExpectation.fulfill()
             }
         }
@@ -203,19 +197,11 @@ class HabitStorageNotificationTests: IntegrationTestCase {
         Timer.scheduledTimer(withTimeInterval: 0.01, repeats: false) { _ in
             // - assert on the number of user notifications
             self.notificationCenterMock.getPendingNotificationRequests { requests in
-
                 XCTAssertEqual(
                     requests.count,
                     dummyHabit.notifications?.count,
                     "The user notifications weren't properly scheduled."
                 )
-
-                // - assert that all notifications were properly scheduled.
-                XCTAssertTrue(
-                    (dummyHabit.notifications as? Set<NotificationMO>)?.filter { !$0.wasScheduled }.count == 0,
-                    "The notifications weren't properly scheduled."
-                )
-
                 rescheduleExpectation.fulfill()
             }
         }
@@ -269,17 +255,10 @@ class HabitStorageNotificationTests: IntegrationTestCase {
 
             // - assert on the number of user notifications
             self.notificationCenterMock.getPendingNotificationRequests { requests in
-
                 XCTAssertEqual(
                     requests.count,
                     dummyHabit.notifications?.count,
                     "The user notifications weren't properly scheduled."
-                )
-
-                // - assert that all notifications were properly scheduled.
-                XCTAssertTrue(
-                    (dummyHabit.notifications as? Set<NotificationMO>)?.filter { !$0.wasScheduled }.count == 0,
-                    "The notifications weren't properly scheduled."
                 )
 
                 rescheduleExpectation.fulfill()
@@ -332,19 +311,11 @@ class HabitStorageNotificationTests: IntegrationTestCase {
 
             // - assert on the number of user notifications
             self.notificationCenterMock.getPendingNotificationRequests { requests in
-
                 XCTAssertEqual(
                     requests.count,
                     dummyHabit.notifications?.count,
                     "The user notifications weren't properly scheduled."
                 )
-
-                // - assert that all notifications were properly scheduled.
-                XCTAssertTrue(
-                    (dummyHabit.notifications as? Set<NotificationMO>)?.filter { !$0.wasScheduled }.count == 0,
-                    "The notifications weren't properly scheduled."
-                )
-
                 rescheduleExpectation.fulfill()
             }
         }

--- a/Habit-Calendar/Habit-Calendar-Tests/Integration Tests/Storage Tests/NotificationStorageTests.swift
+++ b/Habit-Calendar/Habit-Calendar-Tests/Integration Tests/Storage Tests/NotificationStorageTests.swift
@@ -70,7 +70,6 @@ class NotificationStorageTests: IntegrationTestCase {
         XCTAssertNotNil(notification?.fireDate)
         XCTAssertNotNil(notification?.userNotificationId)
         XCTAssertTrue((notification?.dayOrder ?? 0) > 0)
-        XCTAssertFalse(notification?.wasScheduled ?? true)
         XCTAssertEqual(dummyHabit, notification?.habit)
     }
 

--- a/Habit-Calendar/Habit-Calendar.xcodeproj/project.pbxproj
+++ b/Habit-Calendar/Habit-Calendar.xcodeproj/project.pbxproj
@@ -490,6 +490,7 @@
 		475197D52132F4E1009F959C /* HabitDaysSelectionViewController+Calendar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HabitDaysSelectionViewController+Calendar.swift"; sourceTree = "<group>"; };
 		475197D721359516009F959C /* NotificationAvailabilityDisplayable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAvailabilityDisplayable.swift; sourceTree = "<group>"; };
 		4752FDC020FE623900116F1A /* XCTUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTUtils.swift; sourceTree = "<group>"; };
+		4754CE02218D534F00797E59 /* Habit-Calendar-1.0.3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Habit-Calendar-1.0.3.xcdatamodel"; sourceTree = "<group>"; };
 		475C96A120DEFB4C00212E1F /* DummyFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyFactory.swift; sourceTree = "<group>"; };
 		475C96A320DEFC9500212E1F /* DayFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayFactory.swift; sourceTree = "<group>"; };
 		475C96A520DEFEBC00212E1F /* HabitFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HabitFactory.swift; sourceTree = "<group>"; };
@@ -2214,9 +2215,10 @@
 		47F635F620BB920900AC4555 /* Habit-Calendar.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				4754CE02218D534F00797E59 /* Habit-Calendar-1.0.3.xcdatamodel */,
 				47F635F720BB920900AC4555 /* Active.xcdatamodel */,
 			);
-			currentVersion = 47F635F720BB920900AC4555 /* Active.xcdatamodel */;
+			currentVersion = 4754CE02218D534F00797E59 /* Habit-Calendar-1.0.3.xcdatamodel */;
 			path = "Habit-Calendar.xcdatamodeld";
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Habit-Calendar/Habit-Calendar/Controllers/Base.lproj/Main.storyboard
+++ b/Habit-Calendar/Habit-Calendar/Controllers/Base.lproj/Main.storyboard
@@ -701,22 +701,22 @@
                                 </subviews>
                             </stackView>
                             <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jlb-yE-Rbr">
-                                <rect key="frame" x="0.0" y="638" width="414" height="98"/>
+                                <rect key="frame" x="0.0" y="638.33333333333337" width="414" height="97.666666666666629"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="fnn-or-0rW" userLabel="Container view">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="98"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="97.666666666666629"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="zJ1-bL-rA4">
-                                            <rect key="frame" x="135.66666666666669" y="10" width="142.66666666666669" height="78"/>
+                                            <rect key="frame" x="137" y="10" width="140" height="77.666666666666671"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0 fire times selected" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nz0-4c-Qss">
-                                                    <rect key="frame" x="0.0" y="0.0" width="142.66666666666666" height="18"/>
+                                                    <rect key="frame" x="2.6666666666666572" y="0.0" width="134.66666666666666" height="17.666666666666668"/>
                                                     <fontDescription key="fontDescription" name="SFProText-Light" family="SF Pro Text" pointSize="15"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZDt-Pv-rzP" customClass="RoundedButton" customModule="Habit_Calendar" customModuleProvider="target">
-                                                    <rect key="frame" x="1.3333333333333428" y="28" width="140" height="50"/>
+                                                    <rect key="frame" x="0.0" y="27.666666666666629" width="140" height="50"/>
                                                     <color key="backgroundColor" red="0.0" green="0.6588235294" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="50" id="aWW-NN-Ric"/>
@@ -946,22 +946,22 @@
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="717"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="8kz-Ld-lX0" userLabel="Texts">
-                                                <rect key="frame" x="20" y="20" width="374" height="518"/>
+                                                <rect key="frame" x="20" y="20" width="374" height="508"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="67e-Jj-j0e">
-                                                        <rect key="frame" x="0.0" y="0.0" width="297" height="187.66666666666666"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="320.33333333333331" height="183.33333333333334"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="N8k-jJ-xka">
-                                                                <rect key="frame" x="0.0" y="0.0" width="174.66666666666666" height="96"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="171.33333333333334" height="93.333333333333329"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Start new" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x7D-ar-eCD">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="174.66666666666666" height="48"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="171.33333333333334" height="46.666666666666664"/>
                                                                         <fontDescription key="fontDescription" name="SFProDisplay-Bold" family="SF Pro Display" pointSize="40"/>
                                                                         <color key="textColor" red="0.29019607843137252" green="0.29019607843137252" blue="0.29019607843137252" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Habits" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iC7-7Z-GhY">
-                                                                        <rect key="frame" x="0.0" y="48" width="119" height="48"/>
+                                                                        <rect key="frame" x="0.0" y="46.666666666666671" width="115.66666666666667" height="46.666666666666671"/>
                                                                         <fontDescription key="fontDescription" name="SFProDisplay-Bold" family="SF Pro Display" pointSize="40"/>
                                                                         <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                         <nil key="highlightedColor"/>
@@ -969,7 +969,7 @@
                                                                 </subviews>
                                                             </stackView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DM9-ag-tED">
-                                                                <rect key="frame" x="0.0" y="116" width="297" height="71.666666666666686"/>
+                                                                <rect key="frame" x="0.0" y="113.33333333333334" width="320.33333333333331" height="70"/>
                                                                 <string key="text">Change your lifestyle by building 
 new habits and getting things done.
 Add as many habits as you wish.</string>
@@ -980,7 +980,7 @@ Add as many habits as you wish.</string>
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="6JK-0u-PFw">
-                                                        <rect key="frame" x="0.0" y="227.66666666666669" width="372.33333333333331" height="151.66666666666669"/>
+                                                        <rect key="frame" x="0.0" y="223.33333333333331" width="371.33333333333331" height="148.33333333333331"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic-calendar" translatesAutoresizingMaskIntoConstraints="NO" id="EpP-2q-irp">
                                                                 <rect key="frame" x="0.0" y="0.0" width="45" height="47"/>
@@ -989,22 +989,22 @@ Add as many habits as you wish.</string>
                                                                 </constraints>
                                                             </imageView>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="wvE-26-2EX">
-                                                                <rect key="frame" x="60" y="0.0" width="312.33333333333331" height="151.66666666666666"/>
+                                                                <rect key="frame" x="60" y="0.0" width="311.33333333333331" height="148.33333333333334"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Challenge yourself" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fMA-0Y-9jl">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="165" height="24"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="165.33333333333334" height="23.333333333333332"/>
                                                                         <fontDescription key="fontDescription" name="SFProDisplay-Semibold" family="SF Pro Display" pointSize="20"/>
                                                                         <color key="textColor" red="0.29019607843137252" green="0.29019607843137252" blue="0.29019607843137252" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Commit to a habit by beginning a new challenge of days and checking your daily accomplishments." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MLS-wP-bUS">
-                                                                        <rect key="frame" x="0.0" y="34.000000000000007" width="312.33333333333331" height="64.666666666666686"/>
+                                                                        <rect key="frame" x="0.0" y="33.333333333333371" width="311.33333333333331" height="63"/>
                                                                         <fontDescription key="fontDescription" name="SFProText-Regular" family="SF Pro Text" pointSize="18"/>
                                                                         <color key="textColor" red="0.2901960784" green="0.2901960784" blue="0.2901960784" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Keep track of the progress of the challenge, and the days you missed." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dX3-aK-wEC">
-                                                                        <rect key="frame" x="0.0" y="108.66666666666663" width="307.33333333333331" height="43"/>
+                                                                        <rect key="frame" x="0.0" y="106.33333333333337" width="293.33333333333331" height="42"/>
                                                                         <fontDescription key="fontDescription" name="SFProText-Regular" family="SF Pro Text" pointSize="18"/>
                                                                         <color key="textColor" red="0.2901960784" green="0.2901960784" blue="0.2901960784" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
@@ -1014,22 +1014,22 @@ Add as many habits as you wish.</string>
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="IEk-fO-rZ9">
-                                                        <rect key="frame" x="0.0" y="419.33333333333331" width="374" height="98.666666666666686"/>
+                                                        <rect key="frame" x="0.0" y="411.66666666666669" width="358" height="96.333333333333314"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic-notification" translatesAutoresizingMaskIntoConstraints="NO" id="Lng-2y-Vmd">
                                                                 <rect key="frame" x="0.0" y="0.0" width="41" height="46"/>
                                                             </imageView>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="5v2-KJ-ArW">
-                                                                <rect key="frame" x="56" y="0.0" width="318" height="98.666666666666671"/>
+                                                                <rect key="frame" x="56" y="0.0" width="302" height="96.333333333333329"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Get notified" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7gs-8L-Lmk">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="103.33333333333333" height="24"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="104.33333333333333" height="23.333333333333332"/>
                                                                         <fontDescription key="fontDescription" name="SFProDisplay-Semibold" family="SF Pro Display" pointSize="20"/>
                                                                         <color key="textColor" red="0.2901960784" green="0.2901960784" blue="0.2901960784" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Receive daily notifications by configuring the times you wish to get reminded about your habits." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hbQ-cV-prp">
-                                                                        <rect key="frame" x="0.0" y="34.000000000000007" width="318" height="64.666666666666686"/>
+                                                                        <rect key="frame" x="0.0" y="33.333333333333314" width="302" height="63"/>
                                                                         <fontDescription key="fontDescription" name="SFProText-Regular" family="SF Pro Text" pointSize="18"/>
                                                                         <color key="textColor" red="0.2901960784" green="0.2901960784" blue="0.2901960784" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
@@ -1191,31 +1191,31 @@ Add as many habits as you wish.</string>
                                                                 <rect key="frame" x="20" y="0.0" width="374" height="140"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="From 10/09/18, to 25/09/18" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ARc-nS-7ID">
-                                                                        <rect key="frame" x="79.666666666666686" y="0.0" width="215" height="20.333333333333332"/>
+                                                                        <rect key="frame" x="82.333333333333329" y="0.0" width="209.66666666666669" height="20"/>
                                                                         <fontDescription key="fontDescription" name="SFProText-Light" family="SF Pro Text" pointSize="17"/>
                                                                         <color key="textColor" red="0.29019607843137252" green="0.29019607843137252" blue="0.29019607843137252" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="o6T-yK-vKI" userLabel="Prompt">
-                                                                        <rect key="frame" x="0.0" y="35.333333333333378" width="374" height="104.66666666666669"/>
+                                                                        <rect key="frame" x="0.0" y="35" width="374" height="105"/>
                                                                         <subviews>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="30th day" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B0i-n0-rre">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="79" height="21.666666666666668"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="70.333333333333329" height="21"/>
                                                                                 <fontDescription key="fontDescription" name="SFProText-Semibold" family="SF Pro Text" pointSize="18"/>
                                                                                 <color key="textColor" red="0.29019607843137252" green="0.29019607843137252" blue="0.29019607843137252" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="lwa-9h-pWa" userLabel="Question">
-                                                                                <rect key="frame" x="0.0" y="31.666666666666625" width="374" height="43.666666666666657"/>
+                                                                                <rect key="frame" x="0.0" y="31.000000000000004" width="374" height="45.333333333333343"/>
                                                                                 <subviews>
                                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Did you execute this activity today?" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FXo-XX-A07">
-                                                                                        <rect key="frame" x="0.0" y="11.666666666666627" width="304" height="20.333333333333329"/>
+                                                                                        <rect key="frame" x="0.0" y="12.666666666666629" width="304" height="20"/>
                                                                                         <fontDescription key="fontDescription" name="SFProText-Light" family="SF Pro Text" pointSize="17"/>
                                                                                         <nil key="textColor"/>
                                                                                         <nil key="highlightedColor"/>
                                                                                     </label>
                                                                                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FEJ-uZ-PcK">
-                                                                                        <rect key="frame" x="314" y="6.3333333333333712" width="62" height="31"/>
+                                                                                        <rect key="frame" x="314" y="7.3333333333333712" width="62" height="31"/>
                                                                                         <constraints>
                                                                                             <constraint firstAttribute="width" constant="60" id="04V-5V-cUH"/>
                                                                                         </constraints>
@@ -1227,7 +1227,7 @@ Add as many habits as you wish.</string>
                                                                                 </subviews>
                                                                             </stackView>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Yes, I did it." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AkU-5d-3Oh">
-                                                                                <rect key="frame" x="0.0" y="85.333333333333258" width="91.666666666666671" height="19.333333333333329"/>
+                                                                                <rect key="frame" x="0.0" y="86.333333333333371" width="83" height="18.666666666666671"/>
                                                                                 <fontDescription key="fontDescription" name="SFProText-Semibold" family="SF Pro Text" pointSize="16"/>
                                                                                 <color key="textColor" red="0.0" green="0.6588235294117647" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <nil key="highlightedColor"/>
@@ -1265,28 +1265,28 @@ Add as many habits as you wish.</string>
                                                                 <rect key="frame" x="20" y="20" width="374" height="115"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Progress" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tit-Hr-iPN" userLabel="Title">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="92" height="25"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="87.333333333333329" height="25"/>
                                                                         <fontDescription key="fontDescription" name="SFProText-Regular" family="SF Pro Text" pointSize="22"/>
                                                                         <color key="textColor" red="0.29019607843137252" green="0.29019607843137252" blue="0.29019607843137252" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="RxK-1G-Xoa" userLabel="Progress labels">
-                                                                        <rect key="frame" x="0.0" y="35" width="212" height="60"/>
+                                                                        <rect key="frame" x="0.0" y="35" width="199.33333333333334" height="60"/>
                                                                         <subviews>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="8 days to finish the challenge." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sDl-b5-BNm">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="212" height="16.666666666666668"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="199.33333333333334" height="16.666666666666668"/>
                                                                                 <fontDescription key="fontDescription" name="SFProText-Regular" family="SF Pro Text" pointSize="15"/>
                                                                                 <color key="textColor" red="0.29019607843137252" green="0.29019607843137252" blue="0.29019607843137252" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="25 days executed." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qf6-KL-TXJ">
-                                                                                <rect key="frame" x="0.0" y="21.666666666666629" width="129" height="16.666666666666671"/>
+                                                                                <rect key="frame" x="0.0" y="21.666666666666629" width="123.33333333333333" height="16.666666666666671"/>
                                                                                 <fontDescription key="fontDescription" name="SFProText-Regular" family="SF Pro Text" pointSize="15"/>
                                                                                 <color key="textColor" red="0.29019607843137252" green="0.29019607843137252" blue="0.29019607843137252" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="5 days missed." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ACk-Cd-HNW">
-                                                                                <rect key="frame" x="0.0" y="43.333333333333371" width="105.33333333333333" height="16.666666666666671"/>
+                                                                                <rect key="frame" x="0.0" y="43.333333333333371" width="101" height="16.666666666666671"/>
                                                                                 <fontDescription key="fontDescription" name="SFProText-Regular" family="SF Pro Text" pointSize="15"/>
                                                                                 <color key="textColor" red="0.29019607843137252" green="0.29019607843137252" blue="0.29019607843137252" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <nil key="highlightedColor"/>
@@ -1343,22 +1343,22 @@ Add as many habits as you wish.</string>
                                                                 <rect key="frame" x="20" y="20" width="374" height="78"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Fire times" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wUQ-bj-3jO" userLabel="Title">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="101.66666666666667" height="27"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="96" height="27.666666666666668"/>
                                                                         <fontDescription key="fontDescription" name="SFProText-Regular" family="SF Pro Text" pointSize="22"/>
                                                                         <color key="textColor" red="0.2901960784" green="0.2901960784" blue="0.2901960784" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="D14-mG-fKY" userLabel="labels">
-                                                                        <rect key="frame" x="0.0" y="37" width="176" height="41"/>
+                                                                        <rect key="frame" x="0.0" y="37.666666666666629" width="166.66666666666666" height="40.333333333333343"/>
                                                                         <subviews>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="two times were selected:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C8L-3d-lkg">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="176" height="18"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="166.66666666666666" height="17.666666666666668"/>
                                                                                 <fontDescription key="fontDescription" name="SFProText-Regular" family="SF Pro Text" pointSize="15"/>
                                                                                 <color key="textColor" red="0.2901960784" green="0.2901960784" blue="0.2901960784" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="12:00pm, 15:00pm" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aGK-JJ-zui">
-                                                                                <rect key="frame" x="0.0" y="23" width="176" height="18"/>
+                                                                                <rect key="frame" x="0.0" y="22.666666666666742" width="166.66666666666666" height="17.666666666666671"/>
                                                                                 <fontDescription key="fontDescription" name="SFProText-Bold" family="SF Pro Text" pointSize="15"/>
                                                                                 <color key="textColor" red="0.0" green="0.6588235294117647" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <nil key="highlightedColor"/>
@@ -1393,22 +1393,22 @@ Add as many habits as you wish.</string>
                                                                 <rect key="frame" x="20" y="20.000000000000007" width="374" height="113.66666666666669"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Fire times" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sAk-0M-OS2" userLabel="Title">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="101.66666666666667" height="44.666666666666664"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="96" height="46"/>
                                                                         <fontDescription key="fontDescription" name="SFProText-Regular" family="SF Pro Text" pointSize="22"/>
                                                                         <color key="textColor" red="0.2901960784" green="0.2901960784" blue="0.2901960784" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="G6M-72-CPh" userLabel="labels">
-                                                                        <rect key="frame" x="0.0" y="54.666666666666629" width="361.33333333333331" height="59"/>
+                                                                        <rect key="frame" x="0.0" y="56" width="363" height="57.666666666666657"/>
                                                                         <subviews>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="User notifications are not authorized." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qBa-YY-9xH">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="361.33333333333331" height="18"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="363" height="17.666666666666668"/>
                                                                                 <fontDescription key="fontDescription" name="SFProText-Regular" family="SF Pro Text" pointSize="15"/>
                                                                                 <color key="textColor" red="1" green="0.14913141730000001" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enable the user notifications in the Settings app to be reminded of your habits." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="48O-rX-eeq">
-                                                                                <rect key="frame" x="0.0" y="23.000000000000114" width="361.33333333333331" height="36"/>
+                                                                                <rect key="frame" x="0.0" y="22.666666666666742" width="363" height="35"/>
                                                                                 <fontDescription key="fontDescription" name="SFProText-Regular" family="SF Pro Text" pointSize="15"/>
                                                                                 <color key="textColor" red="0.2901960784" green="0.2901960784" blue="0.2901960784" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                                 <nil key="highlightedColor"/>
@@ -1443,23 +1443,23 @@ Add as many habits as you wish.</string>
                                                                 <rect key="frame" x="20" y="20" width="374" height="203"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Fire times" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oEs-Aq-yqx" userLabel="Title">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="101.66666666666667" height="46.666666666666664"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="96" height="68.333333333333329"/>
                                                                         <fontDescription key="fontDescription" name="SFProText-Regular" family="SF Pro Text" pointSize="22"/>
                                                                         <color key="textColor" red="0.2901960784" green="0.2901960784" blue="0.2901960784" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="2zW-27-fPJ" userLabel="labels">
-                                                                        <rect key="frame" x="0.0" y="56.666666666666529" width="340.33333333333331" height="146.33333333333337"/>
+                                                                        <rect key="frame" x="0.0" y="78.333333333333258" width="365.66666666666669" height="124.66666666666669"/>
                                                                         <subviews>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yeb-ra-Zcx">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="340.33333333333331" height="81.333333333333329"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="365.66666666666669" height="59.666666666666664"/>
                                                                                 <string key="text">You currently don’t have any selected fire times for this habit. Fire times help you by reminding you about this habit at specific times of the day.</string>
                                                                                 <fontDescription key="fontDescription" name="SFProText-Regular" family="SF Pro Text" pointSize="17"/>
                                                                                 <color key="textColor" red="0.2901960784" green="0.2901960784" blue="0.2901960784" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iwj-aA-khj" userLabel="New challenge button" customClass="RoundedButton" customModule="Habit_Calendar" customModuleProvider="target">
-                                                                                <rect key="frame" x="80.333333333333314" y="96.333333333333485" width="180" height="50"/>
+                                                                                <rect key="frame" x="93" y="74.666666666666742" width="180" height="50"/>
                                                                                 <color key="backgroundColor" red="0.0" green="0.6588235294" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <constraints>
                                                                                     <constraint firstAttribute="height" constant="50" id="hHV-tu-9bq"/>

--- a/Habit-Calendar/Habit-Calendar/Managers/NotificationScheduler.swift
+++ b/Habit-Calendar/Habit-Calendar/Managers/NotificationScheduler.swift
@@ -85,7 +85,6 @@ struct NotificationScheduler {
             if error == nil {
                 // Set the notification's scheduled flag.
                 notification.managedObjectContext?.perform {
-                    notification.wasScheduled = true
                     completionHandler?(notification)
                 }
             } else {

--- a/Habit-Calendar/Habit-Calendar/Model/DataController.swift
+++ b/Habit-Calendar/Habit-Calendar/Model/DataController.swift
@@ -20,6 +20,12 @@ class DataController {
 
     init(completionBlock: @escaping (Error?) -> Void) {
         persistentContainer = HCPersistentContainer(name: "Habit-Calendar")
+
+        let migrationDescription = NSPersistentStoreDescription()
+        migrationDescription.shouldMigrateStoreAutomatically = true
+        migrationDescription.shouldInferMappingModelAutomatically = true
+
+        persistentContainer.persistentStoreDescriptions.append(migrationDescription)
         persistentContainer.loadPersistentStores(completionHandler: { (_, error) in
             if let error = error as NSError? {
                 #if DEVELOPMENT

--- a/Habit-Calendar/Habit-Calendar/Model/Habit-Calendar.xcdatamodeld/.xccurrentversion
+++ b/Habit-Calendar/Habit-Calendar/Model/Habit-Calendar.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Active.xcdatamodel</string>
+	<string>Habit-Calendar-1.0.3.xcdatamodel</string>
 </dict>
 </plist>

--- a/Habit-Calendar/Habit-Calendar/Model/Habit-Calendar.xcdatamodeld/Habit-Calendar-1.0.3.xcdatamodel/contents
+++ b/Habit-Calendar/Habit-Calendar/Model/Habit-Calendar.xcdatamodeld/Habit-Calendar-1.0.3.xcdatamodel/contents
@@ -53,7 +53,6 @@
         <attribute name="fireDate" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="id" attributeType="String" syncable="YES"/>
         <attribute name="userNotificationId" attributeType="String" syncable="YES"/>
-        <attribute name="wasScheduled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
         <relationship name="habit" maxCount="1" deletionRule="Nullify" destinationEntity="Habit" inverseName="notifications" inverseEntity="Habit" syncable="YES"/>
         <fetchIndex name="byFireDateIndex">
             <fetchIndexElement property="fireDate" type="Binary" order="ascending"/>
@@ -70,7 +69,7 @@
         <element name="FireTime" positionX="-2999" positionY="-3922" width="128" height="118"/>
         <element name="Habit" positionX="-3215" positionY="-3915" width="128" height="178"/>
         <element name="HabitDay" positionX="-3438" positionY="-3978" width="128" height="133"/>
-        <element name="Notification" positionX="-2997" positionY="-3745" width="128" height="133"/>
+        <element name="Notification" positionX="-2997" positionY="-3745" width="128" height="120"/>
         <element name="User" positionX="-3242" positionY="-4131" width="128" height="88"/>
     </elements>
 </model>


### PR DESCRIPTION
The wasScheduled boolean property of the NotificationMO entity was sometimes causing crashes, maybe because it was being modified from a different queue, not sure. Since the attribute isn't needed any longer, (the user notifications sometimes fail,  and there'll be a new manager to re-schedule them every time the app becomes active) there's no need to keep it.