### PR TITLE
Load persistent store only once.

### DIFF
--- a/Habit-Calendar/Habit-Calendar/Model/DataController.swift
+++ b/Habit-Calendar/Habit-Calendar/Model/DataController.swift
@@ -21,11 +21,14 @@ class DataController {
     init(completionBlock: @escaping (Error?) -> Void) {
         persistentContainer = HCPersistentContainer(name: "Habit-Calendar")
 
-        let migrationDescription = NSPersistentStoreDescription()
-        migrationDescription.shouldMigrateStoreAutomatically = true
-        migrationDescription.shouldInferMappingModelAutomatically = true
+        let description = persistentContainer.persistentStoreDescriptions.first ?? NSPersistentStoreDescription()
+        description.shouldMigrateStoreAutomatically = true
+        description.shouldInferMappingModelAutomatically = true
 
-        persistentContainer.persistentStoreDescriptions.append(migrationDescription)
+        if !persistentContainer.persistentStoreDescriptions.contains(description) {
+            persistentContainer.persistentStoreDescriptions.append(description)
+        }
+
         persistentContainer.loadPersistentStores(completionHandler: { (_, error) in
             if let error = error as NSError? {
                 #if DEVELOPMENT


### PR DESCRIPTION
With the change of the store descriptions to migrate automatically, the completion handler was being called twice. This was making the root navigation view controller and the seed to be called twice. That's why there were two users in the persistent store.

Closes #139.