### PR TITLE
The delivered notifications are being removed every time one of them is answered.

### DIFF
--- a/Habit-Calendar/Habit-Calendar/Supporting Files/AppDelegate.swift
+++ b/Habit-Calendar/Habit-Calendar/Supporting Files/AppDelegate.swift
@@ -252,6 +252,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                         self.notificationScheduler.scheduleNotifications(for: habit)
                     }
                 }
+
+                try? context.save()
             }
         }
     }


### PR DESCRIPTION
The app shouldn't remove any delivered notifications, only in the case of migrating from version 1.2 to 1.3 (The version that solves how the notifications are scheduled).

Closes #148.